### PR TITLE
Build CA signing repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,6 +47,7 @@ openvpn_rsa_bits: 2048
 # Duration to validate certs for
 openvpn_cert_days: 3650
 openvpn_ca_cert_days: "{{ openvpn_cert_days }}"
+openvpn_crl_days: "{{ openvpn_cert_days }}"
 openvpn_server_cert_days: "{{ openvpn_cert_days }}"
 openvpn_client_cert_days: "{{ openvpn_cert_days }}"
 
@@ -91,6 +92,7 @@ openvpn_server_config:
   key: "{{ openvpn_key_path }}/server.key"
   dh: "{{ openvpn_key_path }}/dh.pem"
   tls-auth: "{{ openvpn_key_path }}/tls-auth.key"
+  crl-verify: "{{ openvpn_key_path }}/ca.crl"
   tls-server: ''
   auth: SHA256
   cipher: AES-256-CBC

--- a/tasks/openvpn_keys.yml
+++ b/tasks/openvpn_keys.yml
@@ -20,9 +20,9 @@
     mode: '0700'
 
 - name: Drop the openssl extensions
-  copy:
-    src: openssl-extensions.cnf
-    dest: "{{ openvpn_key_path }}/openssl-extensions.cnf"
+  template:
+    src: openssl.cnf.j2
+    dest: "{{ openvpn_key_path }}/openssl.cnf"
     owner: root
     group: root
 

--- a/tasks/openvpn_keys_ca.yml
+++ b/tasks/openvpn_keys_ca.yml
@@ -17,14 +17,16 @@
   command: >
     openssl req
     -nodes
+    -x509
     -newkey
     rsa:{{ openvpn_rsa_bits }}
     -keyout {{ openvpn_key_path }}/ca.key
-    -out {{ openvpn_key_path }}/ca.csr
+    -out {{ openvpn_key_path }}/ca.crt
     -days {{ openvpn_ca_cert_days }}
+    -sha256
     -subj /CN=OpenVPN-CA-{{inventory_hostname}}/
   args:
-    creates: "{{ openvpn_key_path }}/ca.csr"
+    creates: "{{ openvpn_key_path }}/ca.crt"
   changed_when: false
 
 - name: Set permissions on the CA key
@@ -32,17 +34,25 @@
     path: "{{ openvpn_key_path }}/ca.key"
     mode: '0600'
 
-- name: Sign the CA cert
-  command: >
-    openssl x509 -req
-    -in {{ openvpn_key_path }}/ca.csr
-    -out {{ openvpn_key_path }}/ca.crt
-    -signkey {{ openvpn_key_path }}/ca.key
-    -CAcreateserial
-    -sha256
-    -days {{ openvpn_ca_cert_days }}
-    -extfile {{ openvpn_key_path }}/openssl-extensions.cnf
-    -extensions ca
+- name: Create the index.txt and CRL files
+  file:
+    path: "{{ item }}"
+    state: touch
+    owner: root
+    group: root
+  with_items:
+    - "{{ openvpn_key_path }}/index.txt"
+    - "{{ openvpn_key_path }}/ca.crl"
+
+- name: Create the serial and crl numbers
+  shell: "{{ item.command }}"
   args:
-    creates: "{{ openvpn_key_path }}/ca.crt"
+    creates: "{{ item.creates }}"
   changed_when: false
+  with_items:
+    - command: "echo 01 > {{ openvpn_key_path }}/serial"
+      creates: "{{ openvpn_key_path }}/serial"
+    - command: "echo 01 > {{ openvpn_key_path }}/crlnumber"
+      creates: "{{ openvpn_key_path }}/crlnumber"
+  tags:
+    - skip_ansible_lint

--- a/tasks/openvpn_keys_client.yml
+++ b/tasks/openvpn_keys_client.yml
@@ -26,6 +26,15 @@
       {%   endif -%}
       {% endfor -%}
       {{ _var }}
+    openvpn_clients_revoke: >-
+      {% set _var = [] -%}
+      {% for item in openvpn_clients -%}
+      {%   if item is not string
+              and item.revoke | default('no') | bool -%}
+      {%     set _ = _var.append(item.name) -%}
+      {%   endif -%}
+      {% endfor -%}
+      {{ _var }}
 
 - name: Generate the openvpn client keys
   command: >
@@ -36,7 +45,7 @@
     -keyout {{ openvpn_key_path }}/{{ item }}.key
     -out {{ openvpn_key_path }}/{{ item }}.csr
     -days {{ openvpn_client_cert_days }}
-    -subj /CN=OpenVPN-Client-{{ inventory_hostname }}/
+    -subj /CN=OpenVPN-Client-{{ inventory_hostname }}-{{ item }}/
   args:
     creates: "{{ openvpn_key_path }}/{{ item }}.csr"
   with_items: "{{ openvpn_clients_generate }}"
@@ -50,15 +59,34 @@
 
 - name: Sign the openvpn client certs
   command: >
-    openssl x509 -req -sha256
+    openssl ca -batch
+    -config {{ openvpn_key_path }}/openssl.cnf
     -in {{ openvpn_key_path }}/{{ item }}.csr
     -out {{ openvpn_key_path }}/{{ item }}.crt
-    -CA {{ openvpn_key_path }}/ca.crt
-    -CAkey {{ openvpn_key_path }}/ca.key
-    -days {{ openvpn_server_cert_days }}
-    -extfile {{ openvpn_key_path }}/openssl-extensions.cnf
+    -days {{ openvpn_client_cert_days }}
     -extensions client
   args:
     creates: "{{ openvpn_key_path }}/{{ item }}.crt"
   with_items: "{{ openvpn_clients_generate }}"
+  changed_when: false
+
+- name: Perform openvpn certificate revocation
+  command: >
+    openssl ca
+    -config {{ openvpn_key_path }}/openssl.cnf
+    -revoke {{ openvpn_key_path }}/{{ item }}.crt
+  with_items: "{{ openvpn_clients_revoke }}"
+  register: cert_revoke
+  changed_when: cert_revoke.rc == 0
+  failed_when:
+    - cert_revoke.rc == 1
+    - "'Already revoked' not in cert_revoke.stdout"
+
+- name: Update the CRL file
+  command: >
+    openssl ca
+    -config {{ openvpn_key_path }}/openssl.cnf
+    -gencrl
+    -out {{ openvpn_key_path }}/ca.crl
+  when: cert_revoke | changed
   changed_when: false

--- a/tasks/openvpn_keys_server.yml
+++ b/tasks/openvpn_keys_server.yml
@@ -34,14 +34,11 @@
 
 - name: Sign the openvpn server cert
   command: >
-    openssl x509 -req -sha256
+    openssl ca -batch
+    -config {{ openvpn_key_path }}/openssl.cnf
     -in {{ openvpn_key_path }}/server.csr
     -out {{ openvpn_key_path }}/server.crt
-    -CA {{ openvpn_key_path }}/ca.crt
-    -CAkey {{ openvpn_key_path }}/ca.key
-    -CAcreateserial
     -days {{ openvpn_server_cert_days }}
-    -extfile {{ openvpn_key_path }}/openssl-extensions.cnf
     -extensions server
   args:
     creates: "{{ openvpn_key_path }}/server.crt"

--- a/templates/openssl.cnf.j2
+++ b/templates/openssl.cnf.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 # OpenSSL extensions file for generating OpenVPN keys
 
 [client]
@@ -15,7 +16,25 @@ extendedKeyUsage = serverAuth
 keyUsage = digitalSignature,keyEncipherment
 
 [ca]
+default_ca = vpnCA
+
 basicConstraints = CA:TRUE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always
 keyUsage = cRLSign, keyCertSign
+
+[vpnCA]
+dir = {{ openvpn_key_path }}
+certificate = $dir/ca.crt
+private_key = $dir/ca.key
+new_certs_dir = $dir
+database = $dir/index.txt
+serial = $dir/serial
+crlnumber = $dir/crlnumber
+crl = $dir/ca.crl
+default_crl_days = {{ openvpn_crl_days }}
+default_md = sha256
+policy = policy_match
+
+[policy_match]
+commonName = supplied


### PR DESCRIPTION
Instead of performing ad-hoc CA signing, initialize a signing repo
in the keys path. This enables certificate revocation using a crl,
which is now configured to be used by default in OpenVPN.