### PR TITLE
Rewriting testing to support client testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,58 @@
 language: python
+# Test this later.
+cache:
+  timeout: 3600
+  pip: true
+  directories:
+    - $HOME/.docker
+# cache: pip
 services:
   - docker
 env:
   global:
-    - run_opts="-u root --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add NET_ADMIN --cap-add SYS_ADMIN --device /dev/net/tun"
+    - ANSIBLE_FORCE_COLOR=1
+    - docker_image=logan2211/docker-ci
+    - docker_command=/lib/systemd/systemd
+    - cache_dir=$HOME/.docker
   matrix:
-    # LINTERS
+    - TOXENV=linters
+      CACHE_NAME=linters
     - >
-      toxenv=linters
-      tag=ubuntu-xenial
-      image=logan2211/docker-ci
-      init=/lib/systemd/systemd
-    # ANSIBLE 2.1
+      TOXENV=functional_2.1
+      docker_image_tag=ubuntu-xenial
+      CACHE_NAME=xenial
     - >
-      toxenv=functional_2.1
-      tag=ubuntu-xenial
-      image=logan2211/docker-ci
-      init=/lib/systemd/systemd
+      TOXENV=functional_2.1
+      docker_image_tag=centos-7
+      CACHE_NAME=cent7
     - >
-      toxenv=functional_2.1
-      tag=centos-7
-      image=logan2211/docker-ci
-      init=/usr/lib/systemd/systemd
-    # ANSIBLE 2.2
+      TOXENV=functional_2.2
+      docker_image_tag=ubuntu-xenial
+      CACHE_NAME=xenial
     - >
-      toxenv=functional_2.2
-      tag=ubuntu-xenial
-      image=logan2211/docker-ci
-      init=/lib/systemd/systemd
+      TOXENV=functional_2.2
+      docker_image_tag=centos-7
+      CACHE_NAME=cent7
     - >
-      toxenv=functional_2.2
-      tag=centos-7
-      image=logan2211/docker-ci
-      init=/usr/lib/systemd/systemd
-    # ANSIBLE stable (2.3+)
+      TOXENV=functional_stable
+      docker_image_tag=ubuntu-xenial
+      CACHE_NAME=xenial
     - >
-      toxenv=functional_stable
-      tag=ubuntu-xenial
-      image=logan2211/docker-ci
-      init=/lib/systemd/systemd
-    - >
-      toxenv=functional_stable
-      tag=centos-7
-      image=logan2211/docker-ci
-      init=/usr/lib/systemd/systemd
+      TOXENV=functional_stable
+      docker_image_tag=centos-7
+      CACHE_NAME=cent7
 before_install:
-  - 'docker pull ${image}:${tag}'
+  # Load cached docker images
+  - if [[ -d ${cache_dir} ]]; then ls ${cache_dir}/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+  - if [[ -n ${docker_image_tag} ]]; then docker pull ${docker_image}:${docker_image_tag}; fi
+install:
+  - pip install tox
 script:
-  # Create a random file to store the container ID.
-  - container_id=$(mktemp)
-  - 'docker run --detach --volume="${PWD}":/opt/ansiblerole:rw ${run_opts} ${image}:${tag} "${init}" > "${container_id}"'
+  - tox
+before_cache:
+  # Save tagged docker images
   - >
-    docker exec "$(cat ${container_id})"
-    env TERM=xterm
-    env ANSIBLE_FORCE_COLOR=1
-    env toxenv=${toxenv}
-    bash -c 'set -ex; \
-      pushd /opt/ansiblerole; \
-      tox -e ${toxenv}'
+    mkdir -p ${cache_dir} && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
+    | xargs -n 2 -t sh -c 'test -e ${cache_dir}/$1.tar.gz || docker save $0 | gzip -2 > ${cache_dir}/$1.tar.gz'
+notifications:
+  email: false

--- a/tests/common-tasks/docker-create.yml
+++ b/tests/common-tasks/docker-create.yml
@@ -1,0 +1,32 @@
+---
+# Copyright 2017, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Ensure docker-py is installed
+  pip:
+    name: docker-py
+
+- name: Ensure docker container
+  docker_container:
+    name: "{{ inventory_hostname }}"
+    image: "{{ image }}"
+    command: "{{ command | default(omit) }}"
+    privileged: "{{ privileged | default(omit) }}"
+    user: "{{ user | default(omit) }}"
+    volumes: "{{ volumes | default(omit) }}"
+    devices: "{{ devices | default(omit) }}"
+    capabilities: "{{ capabilities | default(omit) }}"
+    state: "{{ state | default(omit) }}"
+    exposed_ports: "{{ exposed_ports | default(omit) }}"
+    links: "{{ links | default(omit) }}"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,22 @@
 [all]
 localhost ansible_connection=local ansible_become=True
+
+[openvpn_servers]
+ovpn_server physical_host=localhost
+
+[openvpn_clients]
+ovpn_client physical_host=localhost
+
+[docker_containers:children]
+openvpn_servers
+openvpn_clients
+
+[docker_containers:vars]
+ansible_connection=docker
+docker_privileged=yes
+docker_user=root
+docker_devices="{{ ['/dev/net/tun'] }}"
+docker_capabilities="{{ ['NET_ADMIN', 'SYS_ADMIN'] }}"
+
+[openvpn_clients:vars]
+container_link_group=openvpn_servers

--- a/tests/test-create-containers.yml
+++ b/tests/test-create-containers.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2017, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create testing containers
+  hosts: docker_containers
+  gather_facts: no
+  tasks:
+    - name: Create base container set
+      include: common-tasks/docker-create.yml
+      vars:
+        image: "{{ docker_image }}:{{ docker_image_tag }}"
+        command: "{{ docker_command }}"
+        volumes: "{{ docker_volumes }}"
+        user: "{{ docker_user | default(omit) }}"
+        privileged: "{{ docker_privileged | default(omit) }}"
+        devices: "{{ docker_devices | default(omit) }}"
+        capabilities: "{{ docker_capabilities | default(omit) }}"
+        exposed_ports: "{{ docker_exposed_ports | default(omit) }}"
+      when: container_link_group is not defined
+      delegate_to: "{{ physical_host }}"
+    - name: Create base container set
+      include: common-tasks/docker-create.yml
+      vars:
+        image: "{{ docker_image }}:{{ docker_image_tag }}"
+        command: "{{ docker_command }}"
+        volumes: "{{ docker_volumes }}"
+        user: "{{ docker_user | default(omit) }}"
+        privileged: "{{ docker_privileged | default(omit) }}"
+        devices: "{{ docker_devices | default(omit) }}"
+        capabilities: "{{ docker_capabilities | default(omit) }}"
+        exposed_ports: "{{ docker_exposed_ports | default(omit) }}"
+        links: "{{ groups[container_link_group] }}"
+      when: container_link_group is defined
+      delegate_to: "{{ physical_host }}"
+  vars:
+    docker_image: "{{ lookup('env', 'docker_image') }}"
+    docker_image_tag: "{{ lookup('env', 'docker_image_tag') }}"
+    docker_command: "{{ lookup('env', 'docker_command') }}"
+    docker_volumes:
+      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: test-create-containers.yml
+
 - name: Playbook for role testing
-  hosts: localhost
-  connection: local
+  hosts: openvpn_servers
   pre_tasks:
     - name: Ensure the openvpn key directory exists
       file:

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ passenv =
     no_proxy
     NO_PROXY
     ANSIBLE_FORCE_COLOR
+    docker_image
+    docker_image_tag
+    docker_command
 whitelist_externals =
     bash
     git


### PR DESCRIPTION
Instead of deploying directly to a container in testing, act on the
host and build the containers as part of the testing playbook. This
allows us to build a second container linked to the server container
as a VPN client and test the connection.