### PR TITLE
Consolidate common config options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,10 +88,31 @@ openvpn_clients: []
 openvpn_clients_config_generate: yes
 openvpn_clients_config_path: "{{ openvpn_key_path }}"
 
+### Configurations are generated using the following override precedence:
+### For Servers:
+###   openvpn_base_config -> openvpn_base_config_overrides ->
+###   openvpn_server_config -> openvpn_server_config_overrides
+### For Clients:
+###   openvpn_base_config -> openvpn_base_config_overrides ->
+###   openvpn_client_config -> openvpn_client_config_overrides
+
+# Config options that are common between client and server
+openvpn_base_config:
+  proto: "{{ openvpn_protocol }}"
+  user: "{{ openvpn_user }}"
+  group: "{{ openvpn_group }}"
+  dev: tun
+  tls-version-min: 1.2
+  auth: SHA256
+  cipher: AES-256-CBC
+  comp-lzo: ''
+  persist-key: ''
+  persist-tun: ''
+  keepalive: '5 30'
+  verb: 3
+
 openvpn_server_config:
   port: "{{ openvpn_port }}"
-  proto: "{{ openvpn_protocol }}"
-  dev: tun
   ca: "{{ openvpn_key_path }}/ca.crt"
   cert: "{{ openvpn_key_path }}/server.crt"
   key: "{{ openvpn_key_path }}/server.key"
@@ -99,45 +120,26 @@ openvpn_server_config:
   tls-auth: "{{ openvpn_key_path }}/tls-auth.key 0"
   crl-verify: "{{ openvpn_key_path }}/ca.crl"
   tls-server: ''
-  auth: SHA256
-  cipher: AES-256-CBC
   server: "{{ openvpn_ipv4_network | ipaddr('network') }} {{ openvpn_ipv4_network | ipaddr('netmask') }}"
-  keepalive: '5 30'
-  comp-lzo: ''
-  persist-key: ''
-  persist-tun: ''
-  user: "{{ openvpn_user }}"
-  group: "{{ openvpn_group }}"
   status: "{{ openvpn_status_file }}"
-  verb: 3
   verify-x509-name: "{{ openvpn_verify_cn_client if (openvpn_verify_cn_enabled | bool) else [] }}"
   remote-cert-tls: client
-  tls-version-min: 1.2
   management: "{{ openvpn_management_bind if (openvpn_management_enabled | bool) else [] }}"
   management-client-user: "{{ openvpn_management_user if (openvpn_management_enabled | bool) else [] }}"
 
 openvpn_client_config:
   client: ''
-  proto: "{{ openvpn_protocol }}"
   remote: "{{ ansible_host }} {{ openvpn_port }}"
-  auth: SHA256
-  cipher: AES-256-CBC
-  dev: tun
   remote-cert-tls: server
-  tls-version-min: 1.2
   resolv-retry: infinite
   nobind: ''
-  keepalive: '5 30'
-  comp-lzo: ''
-  persist-key: ''
-  persist-tun: ''
   key-direction: 1
-  verb: 3
   verify-x509-name: "{{ openvpn_verify_cn_server if (openvpn_verify_cn_enabled | bool) else [] }}"
 
 # Configure settings in this dict to override the base configuration.
 # NOTE(logan): An empty list ie. [] is excluded from the config.
 # NOTE(logan): An empty string is outputted as a key-only var with no
 #              parameter in the config.
+openvpn_base_config_overrides: {}
 openvpn_server_config_overrides: {}
 openvpn_client_config_overrides: {}

--- a/templates/client.ovpn.j2
+++ b/templates/client.ovpn.j2
@@ -1,8 +1,11 @@
 # {{ ansible_managed }}
 
-{% set _ = openvpn_client_config.update(openvpn_client_config_overrides) %}
+{% set openvpn_config = openvpn_base_config %}
+{% set _ = openvpn_config.update(openvpn_base_config_overrides) %}
+{% set _ = openvpn_config.update(openvpn_client_config) %}
+{% set _ = openvpn_config.update(openvpn_client_config_overrides) %}
 
-{% for i in openvpn_client_config | dictsort %}
+{% for i in openvpn_config | dictsort %}
 {%   set key = i.0 %}
 {%   set param = i.1 %}
 {%   if param is iterable and param is not string %}

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,6 +1,8 @@
 # {{ ansible_managed }}
 
-{% set openvpn_config = openvpn_server_config %}
+{% set openvpn_config = openvpn_base_config %}
+{% set _ = openvpn_config.update(openvpn_base_config_overrides) %}
+{% set _ = openvpn_config.update(openvpn_server_config) %}
 {# Set dual stack if needed #}
 {% if openvpn_listen_ipv6 == 'exclusive' %}
 {%   set _ = openvpn_config.update({ 'proto': openvpn_protocol ~ '6' }) %}


### PR DESCRIPTION
A number of OpenVPN config keys are identical between client and
server configurations. This will consolidate the associated configs
and offer a consolidated override path to apply config changes to
both configs at once.