### PR TITLE
Prevent logging of keys in client config generation

### DIFF
--- a/tasks/openvpn_client_configs.yml
+++ b/tasks/openvpn_client_configs.yml
@@ -45,3 +45,6 @@
   with_together:
     - "{{ client_certs.results }}"
     - "{{ client_keys.results }}"
+  # No log is specified to prevent the with_together parameters (ssl keys) from
+  # being outputted to the console by ansible.
+  no_log: yes


### PR DESCRIPTION
Set ansible no_log on the client config generation task to prevent
logging of client keys in the ansible console since the keys are
provided as with_ parameters to the module.